### PR TITLE
Support Deno v0.31.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,8 @@ export * from 'https://deno.land/x/dejs@0.3.1/mod.ts';
 
 ## Installation
 
-### Deno version >= v0.29.0
-
 ```console
-# Install deno_installer (Because deno install in Deno v0.29.0 is broken)
-deno -A https://deno.land/std/installer/mod.ts -- deno_installer https://deno.land/std/installer/mod.ts -A
-
-# Install dem
-deno_installer dem https://deno.land/x/dem@0.3.0/cmd.ts --allow-read --allow-write
-```
-
-### Deno version < v0.29.0
-
-```console
-deno install dem https://deno.land/x/dem@0.2.0/cmd.ts --allow-read --allow-write
+deno install dem https://deno.land/x/dem@0.3.1/cmd.ts --allow-read --allow-write
 ```
 
 ## Usage

--- a/cmd.ts
+++ b/cmd.ts
@@ -1,6 +1,6 @@
 import * as dem from './mod.ts';
 
-export const version = '0.3.0';
+export const version = '0.3.1';
 const defaultConfigFilePath = 'dem.json';
 
 enum SubCommandType {

--- a/cmd.ts
+++ b/cmd.ts
@@ -1,4 +1,3 @@
-const { args } = Deno;
 import * as dem from './mod.ts';
 
 export const version = '0.3.0';
@@ -21,7 +20,7 @@ function isSubCommandType(t: string): t is SubCommandType {
   return commandTypes.includes(t);
 }
 
-async function main(): Promise<void> {
+async function main(args: string[]): Promise<void> {
   const subCmdType = args[0];
   if (!subCmdType) {
     const subCmdTypes = Object.values(SubCommandType).join(', ');
@@ -66,5 +65,9 @@ async function main(): Promise<void> {
 }
 
 if (import.meta.main) {
-  main();
+  let { args } = Deno;
+  if (args[0] === '--') {
+    args = args.slice(1);
+  }
+  main(args);
 }

--- a/dem.json
+++ b/dem.json
@@ -3,7 +3,7 @@
     {
       "protocol": "https",
       "path": "deno.land/std",
-      "version": "v0.29.0",
+      "version": "v0.31.0",
       "files": [
         "/fmt/sprintf.ts",
         "/http/server.ts",

--- a/vendor/https/deno.land/std/fmt/sprintf.ts
+++ b/vendor/https/deno.land/std/fmt/sprintf.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.29.0/fmt/sprintf.ts';
+export * from 'https://deno.land/std@v0.31.0/fmt/sprintf.ts';

--- a/vendor/https/deno.land/std/http/server.ts
+++ b/vendor/https/deno.land/std/http/server.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.29.0/http/server.ts';
+export * from 'https://deno.land/std@v0.31.0/http/server.ts';

--- a/vendor/https/deno.land/std/path/mod.ts
+++ b/vendor/https/deno.land/std/path/mod.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.29.0/path/mod.ts';
+export * from 'https://deno.land/std@v0.31.0/path/mod.ts';


### PR DESCRIPTION
* Deno v0.31.0 is using std@v0.29.0
* This version of std includes `--` in executable script's argument
* But now, Deno doesn't need `--` to pass argument
* `--` is passed as argument
* This change ignores `--` passed as an argument