### PR TITLE
Add support for Deno v0.34.0

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -5,7 +5,7 @@ export type Config = {
   modules: Module[];
 };
 
-function validateConfig(config: any) {
+function validateConfig(config: Config) {
   if (typeof config !== 'object') {
     throw new Error(`config type must be 'object'. actual: '${typeof config}'`);
   }
@@ -26,7 +26,7 @@ function validateConfig(config: any) {
 export async function getConfig(filePath: string): Promise<Config | undefined> {
   const dec = new TextDecoder('utf-8');
   const jsonBody = dec.decode(await readFile(filePath));
-  const config = JSON.parse(jsonBody);
+  const config = JSON.parse(jsonBody) as Config;
   try {
     validateConfig(config);
   } catch (e) {

--- a/mod.ts
+++ b/mod.ts
@@ -224,7 +224,7 @@ export async function remove(
     return;
   }
   let foundModIndex = 0;
-  let foundMod: Module;
+  let foundMod: Module | undefined;
   for (const mod of config.modules) {
     if (urlStr.startsWith(mod.toString())) {
       foundMod = mod;


### PR DESCRIPTION
##  What problem this PR fixes

Compililation fails on Deno v0.34.0.

This is due to TS script mode being enabled since Deno v0.34.0.

Ref: https://github.com/denoland/deno/releases/tag/v0.34.0