### PR TITLE
Update Deno to v0.42.0

### DIFF
--- a/dem.json
+++ b/dem.json
@@ -3,7 +3,7 @@
     {
       "protocol": "https",
       "path": "deno.land/std",
-      "version": "v0.38.0",
+      "version": "v0.42.0",
       "files": [
         "/fmt/sprintf.ts",
         "/http/server.ts",

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
-const { cwd, mkdir, writeFile, remove: removeFile, readdir, readFile } = Deno;
+const { cwd, mkdir, writeFile, remove: removeFile, readDir, readFile } = Deno;
 
 import { getConfig, saveConfig, Config } from "./config.ts";
 import { Module } from "./module.ts";
@@ -58,8 +58,7 @@ to update module, please use 'dem update'.`);
   config.modules.sort(compareModules);
   await saveConfig(config, configFilePath);
   console.log(
-    `successfully added new module: ${addedMod
-      .toString()}, version: ${addedMod.version}`,
+    `successfully added new module: ${addedMod.toString()}, version: ${addedMod.version}`,
   );
 }
 
@@ -159,8 +158,7 @@ export async function update(
 
   await saveConfig(config, configFilePath);
   console.log(
-    `successfully updated module: ${updatedMod
-      .toString()}, version: ${updatedMod.version}`,
+    `successfully updated module: ${updatedMod.toString()}, version: ${updatedMod.version}`,
   );
 }
 
@@ -288,7 +286,7 @@ async function getImportFilePaths(
   excludes: string[],
 ): Promise<string[]> {
   const filePaths: string[] = [];
-  for await (const f of readdir(dirName)) {
+  for await (const f of readDir(dirName)) {
     if (!f.name) {
       continue;
     }

--- a/vendor/https/deno.land/std/fmt/sprintf.ts
+++ b/vendor/https/deno.land/std/fmt/sprintf.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.38.0/fmt/sprintf.ts';
+export * from 'https://deno.land/std@v0.42.0/fmt/sprintf.ts';

--- a/vendor/https/deno.land/std/http/server.ts
+++ b/vendor/https/deno.land/std/http/server.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.38.0/http/server.ts';
+export * from 'https://deno.land/std@v0.42.0/http/server.ts';

--- a/vendor/https/deno.land/std/path/mod.ts
+++ b/vendor/https/deno.land/std/path/mod.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.38.0/path/mod.ts';
+export * from 'https://deno.land/std@v0.42.0/path/mod.ts';


### PR DESCRIPTION
- Updated std to v0.42.0.
  - `Deno.readdir` was renamed to `Deno.readDir` from Deno@v0.42.0.