### PR TITLE
Run "deno lint" in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ TARGET_SRC=$(shell shopt -s globstar && ls ./*.ts | grep -v ./vendor)
 
 lint:
 	deno fmt --check $(TARGET_SRC)
+	deno lint --unstable $(TARGET_SRC)
 
 fmt:
 	deno fmt $(TARGET_SRC)


### PR DESCRIPTION
@syumai
"deno lint" is still unstable.
If you cannot accept it, please close this PR :smile:

## Pros & Cons of introducing "deno lint"

### Pros

- It reduces the probability of introducing minor bugs.

### Cons

- The frequency of CI failures may increase in the future.
- "deno lint" is still unstable.