### PR TITLE
Use GITHUB_PATH instead of add-path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dem-local
         run: |
           make install-local
-          echo "::add-path::$HOME/.deno/bin"
+          echo $HOME/.deno/bin >> $GITHUB_PATH
       - name: Run tests
         run: |
           make test


### PR DESCRIPTION
`add-path` command is now deprecated. This PR fixes CI workflow to use `GITHUB_PATH` instead of `add-path` command.
## Ref
* https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
* https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path